### PR TITLE
Add support for dockerization of the kernel

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -51,6 +51,14 @@ List of environment variables than can override xml properties:
 - miner_address
 - peer_list
 - override_peer_list
+- log_level_db
+- log_level_vm
+- log_level_gen
+- log_level_api
+- log_level_sync
+- log_level_cons
+- log_file
+- log_path
 ```
 
 If you need to override more properties update `aion-docker.py` to support those properties.

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,4 +1,4 @@
-#Dockerization
+# Dockerization
 
 The kernel can be deployed as a container using the Dockerfile present in the root of the repo.
 Currently there is no automated way to build it but it provides an argument to pick the release you want to use to build the image.

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,28 +1,22 @@
 # Dockerization
 
-The kernel can be deployed as a container using the Dockerfile present in the root of the repo.
-Currently there is no automated way to build it but it provides an argument to pick the release you want to use to build the image.
+The kernel can be deployed as a container using the Dockerfile present in the root of the repo. 
+The docker image can be built and pushed using the `pack_docker` and `push_docker` ant targets.
 
 ## Building
 
-Building is done by specifying the `kernel_archive` argument which is a full URL to the github kernel release.
-Make sure you tag the image correctly by specifying the `version_tag`.
-
-Note: You can use your own registry or build locally, but you need to specify the repository of the image
-if you intend to push it to the `centrys` docker registry.
-
 ```bash
-docker build -t \
-centrys/aion-docker:<version_tag> . \
---build-arg kernel_archive=https://github.com/aionnetwork/aion/releases/download/<version>/<archive>
+ant pack_docker
 ```
 
-Eg:
+This command will create 2 docker images
+- centrys/aion-core:<kernelversionshortcommit>
+- centrys/aion-core:latest
+
+In order to have the image available for deployments you need to push it to the registry using the `push_docker` target
 
 ```bash
-docker build -t \
-centrys/aion-docker:v0.2.7 . \
---build-arg kernel_archive=https://github.com/aionnetwork/aion/releases/download/v0.2.7/aion-v0.2.7.1bbeec1-2018-05-24.tar.bz2
+ant push_docker
 ```
 
 ## Running
@@ -36,7 +30,7 @@ Eg:
 docker run -it \
 -e java_api_listen_address=0.0.0.0 \
 -e rpc_listen_address=0.0.0.0 \
-aion-docker:v0.2.7
+aion-core:v0.2.7b1677af
 ```
 
 List of environment variables than can override xml properties:

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,58 @@
+#Dockerization
+
+The kernel can be deployed as a container using the Dockerfile present in the root of the repo.
+Currently there is no automated way to build it but it provides an argument to pick the release you want to use to build the image.
+
+## Building
+
+Building is done by specifying the `kernel_archive` argument which is a full URL to the github kernel release.
+Make sure you tag the image correctly by specifying the `version_tag`.
+
+Note: You can use your own registry or build locally, but you need to specify the repository of the image
+if you intend to push it to the `centrys` docker registry.
+
+```bash
+docker build -t \
+centrys/aion-docker:<version_tag> . \
+--build-arg kernel_version=https://github.com/aionnetwork/aion/releases/download/<version>/<archive>
+```
+
+Eg:
+
+```bash
+docker build -t \
+centrys/aion-docker:v0.2.7 . \
+--build-arg kernel_version=https://github.com/aionnetwork/aion/releases/download/v0.2.7/aion-v0.2.7.1bbeec1-2018-05-24.tar.bz2
+```
+
+## Running
+
+You can start your kernel container using the `docker run` command and you can override a few parameters by passing
+environment variables to the command.
+
+Eg:
+
+```bash
+docker run -it \
+-e java_api_listen_address=0.0.0.0 \
+-e rpc_listen_address=0.0.0.0 \
+aion-docker:v0.2.7
+```
+
+List of environment variables than can override xml properties:
+
+```bash
+- rpc_listen_address
+- rpc_listen_port
+- cors_enabled
+- apis_enabled
+- java_api_listen_address
+- java_api_listen_port
+- p2p_listen_address
+- p2p_listen_port
+- discover
+- mining
+- miner_address
+```
+
+If you need to override more properties update `aion-docker.py` to support those properties.

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -14,7 +14,7 @@ if you intend to push it to the `centrys` docker registry.
 ```bash
 docker build -t \
 centrys/aion-docker:<version_tag> . \
---build-arg kernel_version=https://github.com/aionnetwork/aion/releases/download/<version>/<archive>
+--build-arg kernel_archive=https://github.com/aionnetwork/aion/releases/download/<version>/<archive>
 ```
 
 Eg:
@@ -22,7 +22,7 @@ Eg:
 ```bash
 docker build -t \
 centrys/aion-docker:v0.2.7 . \
---build-arg kernel_version=https://github.com/aionnetwork/aion/releases/download/v0.2.7/aion-v0.2.7.1bbeec1-2018-05-24.tar.bz2
+--build-arg kernel_archive=https://github.com/aionnetwork/aion/releases/download/v0.2.7/aion-v0.2.7.1bbeec1-2018-05-24.tar.bz2
 ```
 
 ## Running

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -28,8 +28,10 @@ Eg:
 
 ```bash
 docker run -it \
--e java_api_listen_address=0.0.0.0 \
--e rpc_listen_address=0.0.0.0 \
+-e java_api_listen_address="0.0.0.0" \
+-e rpc_listen_address="0.0.0.0" \
+-e peer_list="p2p://peer-id-1@10.10.10.10:3333,p2p://peer-id-2@12.12.12.12:4444" \
+-e override_peer_list="true"
 aion-core:v0.2.7b1677af
 ```
 
@@ -47,6 +49,8 @@ List of environment variables than can override xml properties:
 - discover
 - mining
 - miner_address
+- peer_list
+- override_peer_list
 ```
 
 If you need to override more properties update `aion-docker.py` to support those properties.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,13 @@
 FROM openjdk:9
 
-#TODO: this image downloads a release of the kernel and uses ENV variables in order to override some parameters in config.xml
-#TODO: 1. integrate image creation in the ant build of the kernel
-#TODO: 2. allow program parameters to be passed when the kernel starts to avoid the config override and remove this step from the Dockerfile
-
 MAINTAINER alexandru.laurus@centrys.io
 
 RUN mkdir -p /opt/aion
 
-RUN apt-get update && apt-get install -y wget
+ARG kernel_path
 
-ARG kernel_archive
-RUN echo $kernel_archive
-
-RUN wget ${kernel_archive} -O aion.tar.gz && tar -xf aion.tar.gz && cd aion
-
-ADD . /opt/aion
+COPY ${kernel_path} /opt/aion/
 
 WORKDIR /opt/aion
 
 CMD [ "python", "aion-docker.py" ]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM openjdk:9
+
+#TODO: this image downloads a release of the kernel and uses ENV variables in order to override some parameters in config.xml
+#TODO: 1. integrate image creation in the ant build of the kernel
+#TODO: 2. allow program parameters to be passed when the kernel starts to avoid the config override and remove this step from the Dockerfile
+
+MAINTAINER alexandru.laurus@centrys.io
+
+RUN mkdir -p /opt/aion
+
+RUN apt-get update && apt-get install -y wget
+
+ARG kernel_archive
+RUN echo $kernel_archive
+
+RUN wget ${kernel_archive} -O aion.tar.gz && tar -xf aion.tar.gz && cd aion
+
+ADD . /opt/aion
+
+WORKDIR /opt/aion
+
+CMD [ "python", "aion-docker.py" ]
+

--- a/aion-docker.py
+++ b/aion-docker.py
@@ -1,0 +1,40 @@
+import os
+import xml.etree.ElementTree
+import subprocess
+
+def override_attrib(element, attrib,  name, value):
+    if name != None and value != None:
+        print('Overriding kernel property ' + name + ' attribute ' + attrib + ' with value ' + value)
+        element.attrib[attrib] = value
+
+def override_child_text(element, child, name, value):
+    if name != None and value != None:
+        print('Overriding kernel property ' + name + ' with value ' + value)
+        element.find(child).text = value
+
+et = xml.etree.ElementTree.parse('config/config.xml')
+root = et.getroot()
+
+api = root.find('api')
+new_rpc = api.find('rpc')
+override_attrib(new_rpc, 'ip', 'rpc_listen_address', os.environ.get('rpc_listen_address'))
+override_attrib(new_rpc, 'port', 'rpc_listen_port', os.environ.get('rpc_listen_port'))
+override_child_text(new_rpc, 'cors-enabled', 'cors_enabled', os.environ.get('cors_enabled'))
+override_child_text(new_rpc, 'apis-enabled', 'apis_enabled', os.environ.get('apis_enabled'))
+
+new_java = api.find('java')
+override_attrib(new_java, 'ip', 'java_api_listen_address', os.environ.get('java_api_listen_address'))
+override_attrib(new_java, 'port', 'java_api_listen_port', os.environ.get('java_api_listen_port'))
+
+new_net = root.find('p2p')
+override_child_text(new_net, 'ip', 'p2p_listen_address', os.environ.get('p2p_listen_address'))
+override_child_text(new_net, 'port', 'p2p_listen_port', os.environ.get('p2p_listen_port'))
+override_child_text(new_net, 'discover', 'discover', os.environ.get('discover'))
+
+new_consensus = root.find('consensus')
+override_child_text(new_consensus, 'mining', 'mining', os.environ.get('mining'))
+override_child_text(new_consensus, 'miner-address', 'miner_address', os.environ.get('miner_address'))
+
+et.write('config/config.xml')
+
+subprocess.call(['/bin/bash', '-c', './aion.sh'])

--- a/aion-docker.py
+++ b/aion-docker.py
@@ -83,6 +83,16 @@ new_consensus = root.find('consensus')
 override_child_text(new_consensus, 'mining', 'mining', os.environ.get('mining'))
 override_child_text(new_consensus, 'miner-address', 'miner_address', os.environ.get('miner_address'))
 
+new_log = root.find('log')
+override_child_text(new_log, 'log-file', 'log_file', os.environ.get('log_file'))
+override_child_text(new_log, 'log-path', 'log_path', os.environ.get('log_path'))
+override_child_text(new_log, 'GEN', 'log_level_gen', os.environ.get('log_level_gen'))
+override_child_text(new_log, 'VM', 'log_level_vm', os.environ.get('log_level_vm'))
+override_child_text(new_log, 'API', 'log_level_api', os.environ.get('log_level_api'))
+override_child_text(new_log, 'SYNC', 'log_level_sync', os.environ.get('log_level_sync'))
+override_child_text(new_log, 'CONS', 'log_level_cons', os.environ.get('log_level_cons'))
+override_child_text(new_log, 'DB', 'log_level_db', os.environ.get('log_level_db'))
+
 indent(root)
 et.write(config_file, encoding='utf-8', xml_declaration=True)
 

--- a/aion.sh
+++ b/aion.sh
@@ -37,5 +37,21 @@ ARG=$@
 # add execute permission to rt
 chmod +x ./rt/bin/*
 
-env EVMJIT="-cache=1" ./rt/bin/java -Xms4g \
+# this will append to the right of $JAVA_OPTS if it's already present on the server
+# the rightmost value of the heapsize parameters will be picked up by the jvm so we should be safe
+
+JAVA_OPTS=$JAVA_OPTS
+
+if [ ! -z "$CORE_XMX" ]; then
+    JAVA_OPTS="$JAVA_OPTS -Xmx$CORE_XMX"
+fi
+
+if [ ! -z "$CORE_XMS" ]; then
+    JAVA_OPTS="$JAVA_OPTS -Xms$CORE_XMS"
+else
+    JAVA_OPTS="$JAVA_OPTS -Xms4g"
+fi
+
+
+env EVMJIT="-cache=1" ./rt/bin/java $JAVA_OPTS \
         -cp "./lib/*:./lib/libminiupnp/*:./mod/*" org.aion.Aion "$@"

--- a/build.xml
+++ b/build.xml
@@ -373,6 +373,7 @@
 			</tarfileset>
 			<tarfileset dir="${dir.workspace}" filemode="755" prefix="${project.name}">
 				<include name="aion.sh" />
+				<include name="aion-docker.py" />
 			</tarfileset>
 			<tarfileset dir="${dir.pack}/config" filemode="755" prefix="${project.name}/config">
 				<include name="**" />

--- a/build.xml
+++ b/build.xml
@@ -392,4 +392,17 @@
 			<arg value="${dir.workspace}/script/postpack.sh" />
 		</exec>
 	</target>
+
+	<target name="pack_docker">
+		<exec executable="/bin/bash">
+			<arg value="${dir.workspace}/script/pack_docker.sh" />
+		</exec>
+	</target>
+
+	<target name="push_docker">
+		<exec executable="/bin/bash">
+			<arg value="${dir.workspace}/script/push_docker.sh" />
+		</exec>
+	</target>
+
 </project>

--- a/script/pack_docker.sh
+++ b/script/pack_docker.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+PACK_PATH='pack'
+
+cd $PACK_PATH
+BIN_ARCHIVE=$(ls aion-*tar*)
+tar xvjf $BIN_ARCHIVE
+VERSION=$(./aion/aion.sh --version)
+
+docker build -t centrys/aion-core:latest ../. --build-arg kernel_path="$PACK_PATH/aion/"
+docker tag centrys/aion-core:latest centrys/aion-core:$VERSION
+
+rm -rf aion/
+
+cd ..
+
+

--- a/script/push_docker.sh
+++ b/script/push_docker.sh
@@ -1,0 +1,17 @@
+ #!/bin/bash
+
+ PACK_PATH='pack'
+
+ cd $PACK_PATH
+ BIN_ARCHIVE=$(ls aion-*tar*)
+ tar xvjf $BIN_ARCHIVE
+ VERSION=$(./aion/aion.sh --version)
+
+ docker push centrys/aion-core:latest
+ docker push centrys/aion-core:$VERSION
+
+ rm -rf aion/
+
+ cd ..
+
+


### PR DESCRIPTION
**What was the issue**

Dockerize the kernel for cloud deployment and prepare the enterprise blockchain soultion

**What was the solution**
* [x] Adds support for dockerization
* [x] Adds support for overriding properties in `config.xml` by specifying environment variables. (python is a prerequisite and only a handful of properties are supported) 
* [x] Override JVM heapsize and peers

**How to test**

Run with docker
```bash
docker run -it \
-e java_api_listen_address="0.0.0.0" \
-e rpc_listen_address="0.0.0.0" \
-e peer_list="p2p://peer-id-1@10.10.10.10:3333,p2p://peer-id-2@12.12.12.12:4444" \
-e override_peer_list="true"
aion-core:v0.2.7b1677af
```

Running without docker
```bash
java_rpc_listen_address=0.0.0.0 python aion-docker.py 
```
